### PR TITLE
Removed runAsUser from cloud_sql_proxy

### DIFF
--- a/charts/forseti-security/templates/database/_cloudsqlproxy-container.yaml
+++ b/charts/forseti-security/templates/database/_cloudsqlproxy-container.yaml
@@ -19,6 +19,5 @@
   args:
   - -instances={{ .Values.database.connectionName }}=tcp:0.0.0.0:3306
   securityContext:
-    runAsUser: 2
     allowPrivilegeEscalation: false
 {{ end -}}


### PR DESCRIPTION
Starting with [Release v1.17](https://github.com/GoogleCloudPlatform/cloudsql-proxy/releases/tag/v1.17.0) cloudsql-proxy started specifying a non-root user in their [Dockerfile](https://github.com/GoogleCloudPlatform/cloudsql-proxy/blob/v1.17.0/Dockerfile#L29).  This causes [issues](https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/385) with deployments that have a non-root user specified.

Removed specified non-root user from security context